### PR TITLE
Fixing minor typo in README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ An R package for generating paragraphs of lorem ipsum.
 You can install the package using `devtools`:
 
 ```{r, eval=FALSE}
-devtools::install_github("aakosm/ipsum")
+devtools::install_github("aakosm/lipsum")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ install
 You can install the package using `devtools`:
 
 ``` r
-devtools::install_github("aakosm/ipsum")
+devtools::install_github("aakosm/lipsum")
 ```
 
 how it works


### PR DESCRIPTION
Fixing minor typo in package name argument on `devtools::install_github()` in README.Rmd